### PR TITLE
first version of the packages and repos

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,12 +1,28 @@
 {
   "apt": [
     "curl",
-    "wget"
+    "wget",
+    "libreoffice",
+    "build-essential",
+    "vim",
+    "gimp",
+    "librecad",
+    "flatpak",
+    "python3",
+    "python3-pip",
+    "software-properties-common"
+  ],
+  "apt-repos": [
+    "ppa:libreoffice",
+    "ppa:otto-kesselgulasch/gimp"
   ],
   "flatpak": [
-    "cc.arduino.IDE2"
+    "cc.arduino.IDE2",
+    "one.ablaze.floorp"
   ],
   "snap": [
-    "code"
+    "code",
+    "clion",
+    "pycharm-educational"
   ]
 }


### PR DESCRIPTION
### Added software packages:
* Added several new `apt` packages: `libreoffice`, `build-essential`, `vim`, `gimp`, `librecad`, `flatpak`, `python3`, `python3-pip`, and `software-properties-common`.

### Added repositories:
* Added new `apt-repos` entries: `ppa:libreoffice` and `ppa:otto-kesselgulasch/gimp`.

### Added snap applications:
* Added new `snap` applications: `clion` and `pycharm-educational`.

### Added flatpak applications:
* Added new `flatpak` application: `one.ablaze.floorp`.